### PR TITLE
Fixed index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Docker = require('dockerode');
 
 var wrappedProto = Docker.prototype;


### PR DESCRIPTION
Am able to run in Node v5 without transpiling with use strict.
Without it gives:
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
Had to run Node v5 with --harmony_rest_parameters